### PR TITLE
Fix-warnings-treat-as-errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: dotnet restore vscode-restclient-dotnet.slnx
       
     - name: Build
-      run: dotnet build vscode-restclient-dotnet.slnx --no-restore --configuration Release
+      run: dotnet build vscode-restclient-dotnet.slnx --no-restore --configuration Release --verbosity minimal
       
     - name: Test
       run: dotnet test vscode-restclient-dotnet.slnx --no-build --configuration Release --verbosity normal --logger trx --results-directory TestResults
@@ -55,7 +55,7 @@ jobs:
       run: dotnet restore vscode-restclient-dotnet.slnx
       
     - name: Build
-      run: dotnet build vscode-restclient-dotnet.slnx --no-restore --configuration Release
+      run: dotnet build vscode-restclient-dotnet.slnx --no-restore --configuration Release --verbosity minimal
       
     - name: Test with coverage
       run: dotnet test vscode-restclient-dotnet.slnx --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory TestResults
@@ -88,7 +88,7 @@ jobs:
       run: dotnet restore vscode-restclient-dotnet.slnx
       
     - name: Build
-      run: dotnet build vscode-restclient-dotnet.slnx --no-restore --configuration Release
+      run: dotnet build vscode-restclient-dotnet.slnx --no-restore --configuration Release --verbosity minimal
       
     - name: Test
       run: dotnet test vscode-restclient-dotnet.slnx --no-build --configuration Release --verbosity normal

--- a/src/RESTClient.NET.Core/HttpFileProcessor.cs
+++ b/src/RESTClient.NET.Core/HttpFileProcessor.cs
@@ -37,7 +37,7 @@ namespace RESTClient.NET.Core
         /// <param name="filePath">Path to the HTTP file</param>
         /// <param name="options">Parsing options</param>
         /// <returns>Parsed HTTP file</returns>
-        public async Task<HttpFile> ParseFileAsync(string filePath, HttpParseOptions options = null)
+        public async Task<HttpFile> ParseFileAsync(string filePath, HttpParseOptions? options = null)
         {
             if (string.IsNullOrWhiteSpace(filePath))
                 throw new ArgumentException("File path cannot be null or empty", nameof(filePath));
@@ -56,7 +56,7 @@ namespace RESTClient.NET.Core
         /// <param name="content">HTTP file content</param>
         /// <param name="options">Parsing options</param>
         /// <returns>Parsed HTTP file</returns>
-        public Task<HttpFile> ParseContentAsync(string content, HttpParseOptions options = null)
+        public Task<HttpFile> ParseContentAsync(string content, HttpParseOptions? options = null)
         {
             if (content == null)
                 throw new ArgumentNullException(nameof(content));
@@ -211,7 +211,7 @@ namespace RESTClient.NET.Core
 
             _logger?.LogDebug("Processing request '{RequestName}'", requestName);
 
-            return VariableProcessor.ProcessRequest(request, httpFile.FileVariables, environmentVariables);
+            return VariableProcessor.ProcessRequest(request!, httpFile.FileVariables, environmentVariables);
         }
 
         /// <summary>

--- a/src/RESTClient.NET.Core/Models/HttpFile.cs
+++ b/src/RESTClient.NET.Core/Models/HttpFile.cs
@@ -103,51 +103,5 @@ namespace RESTClient.NET.Core.Models
         {
             return _requestsByName.ContainsKey(name);
         }
-
-        // Backward compatibility methods - these will be removed in a future version
-        /// <summary>
-        /// Gets an HTTP request by its unique ID
-        /// </summary>
-        /// <param name="requestId">The request ID to search for</param>
-        /// <returns>The HTTP request with the specified ID</returns>
-        /// <exception cref="System.Collections.Generic.KeyNotFoundException">Thrown when no request with the specified ID is found</exception>
-        [Obsolete("Use GetRequestByName instead. This method will be removed in a future version.")]
-        public HttpRequest GetRequestById(string requestId)
-        {
-            return GetRequestByName(requestId);
-        }
-
-        /// <summary>
-        /// Attempts to get an HTTP request by its unique ID
-        /// </summary>
-        /// <param name="requestId">The request ID to search for</param>
-        /// <param name="request">When this method returns, contains the HTTP request if found; otherwise, null</param>
-        /// <returns>true if a request with the specified ID was found; otherwise, false</returns>
-        [Obsolete("Use TryGetRequestByName instead. This method will be removed in a future version.")]
-        public bool TryGetRequestById(string requestId, out HttpRequest? request)
-        {
-            return TryGetRequestByName(requestId, out request);
-        }
-
-        /// <summary>
-        /// Gets all unique request IDs in the file
-        /// </summary>
-        /// <returns>A collection of request IDs</returns>
-        [Obsolete("Use GetRequestNames instead. This method will be removed in a future version.")]
-        public IEnumerable<string> GetRequestIds()
-        {
-            return GetRequestNames();
-        }
-
-        /// <summary>
-        /// Checks if a request with the specified ID exists
-        /// </summary>
-        /// <param name="requestId">The request ID to check</param>
-        /// <returns>true if a request with the specified ID exists; otherwise, false</returns>
-        [Obsolete("Use ContainsRequestName instead. This method will be removed in a future version.")]
-        public bool ContainsRequestId(string requestId)
-        {
-            return ContainsRequestName(requestId);
-        }
     }
 }

--- a/src/RESTClient.NET.Core/Models/HttpFile.cs
+++ b/src/RESTClient.NET.Core/Models/HttpFile.cs
@@ -64,7 +64,7 @@ namespace RESTClient.NET.Core.Models
         {
             if (TryGetRequestByName(name, out var request))
             {
-                return request;
+                return request!;
             }
             
             throw new KeyNotFoundException($"Request with name '{name}' not found");

--- a/src/RESTClient.NET.Core/Models/HttpRequest.cs
+++ b/src/RESTClient.NET.Core/Models/HttpRequest.cs
@@ -14,16 +14,6 @@ namespace RESTClient.NET.Core.Models
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the unique request identifier
-        /// </summary>
-        [Obsolete("Use Name property instead. This property will be removed in a future version.")]
-        public string RequestId
-        {
-            get => Name;
-            set => Name = value;
-        }
-
-        /// <summary>
         /// Gets or sets the HTTP method (GET, POST, PUT, DELETE, etc.)
         /// </summary>
         public string Method { get; set; } = "GET";

--- a/src/RESTClient.NET.Core/Parsing/HttpFileParser.cs
+++ b/src/RESTClient.NET.Core/Parsing/HttpFileParser.cs
@@ -123,7 +123,7 @@ namespace RESTClient.NET.Core.Parsing
 
 #if NETSTANDARD2_0
             var content = File.ReadAllText(filePath);
-            return Parse(content, options);
+            return await Task.FromResult(Parse(content, options)).ConfigureAwait(false);
 #else
             var content = await File.ReadAllTextAsync(filePath).ConfigureAwait(false);
             return Parse(content, options);

--- a/src/RESTClient.NET.Core/Parsing/HttpParseOptions.cs
+++ b/src/RESTClient.NET.Core/Parsing/HttpParseOptions.cs
@@ -13,16 +13,6 @@ namespace RESTClient.NET.Core.Parsing
         public bool ValidateRequestNames { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to validate request IDs for uniqueness and format
-        /// </summary>
-        [Obsolete("Use ValidateRequestNames instead. This property will be removed in a future version.")]
-        public bool ValidateRequestIds
-        {
-            get => ValidateRequestNames;
-            set => ValidateRequestNames = value;
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether to process variable references
         /// </summary>
         public bool ProcessVariables { get; set; } = true;
@@ -43,16 +33,6 @@ namespace RESTClient.NET.Core.Parsing
         public bool RequireRequestNames { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to require request IDs for all requests
-        /// </summary>
-        [Obsolete("Use RequireRequestNames instead. This property will be removed in a future version.")]
-        public bool RequireRequestIds
-        {
-            get => RequireRequestNames;
-            set => RequireRequestNames = value;
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether to allow empty request bodies
         /// </summary>
         public bool AllowEmptyBodies { get; set; } = true;
@@ -66,16 +46,6 @@ namespace RESTClient.NET.Core.Parsing
         /// Gets or sets the maximum allowed request name length
         /// </summary>
         public int MaxRequestNameLength { get; set; } = 50;
-
-        /// <summary>
-        /// Gets or sets the maximum allowed request ID length
-        /// </summary>
-        [Obsolete("Use MaxRequestNameLength instead. This property will be removed in a future version.")]
-        public int MaxRequestIdLength
-        {
-            get => MaxRequestNameLength;
-            set => MaxRequestNameLength = value;
-        }
 
         /// <summary>
         /// Gets or sets a value indicating whether to ignore unknown metadata comments

--- a/src/RESTClient.NET.Core/Parsing/HttpTokens.cs
+++ b/src/RESTClient.NET.Core/Parsing/HttpTokens.cs
@@ -67,12 +67,6 @@ namespace RESTClient.NET.Core.Parsing
         RequestName,
 
         /// <summary>
-        /// Request ID
-        /// </summary>
-        [Obsolete("Use RequestName instead. This value will be removed in a future version.")]
-        RequestId = RequestName,
-
-        /// <summary>
         /// HTTP method
         /// </summary>
         Method,

--- a/src/RESTClient.NET.Core/Processing/VariableProcessor.cs
+++ b/src/RESTClient.NET.Core/Processing/VariableProcessor.cs
@@ -21,7 +21,7 @@ namespace RESTClient.NET.Core.Processing
         /// <param name="fileVariables">File-level variables</param>
         /// <param name="environmentVariables">Environment variables</param>
         /// <returns>Content with variables resolved</returns>
-        public static string ResolveVariables(
+        public static string? ResolveVariables(
             string? content, 
             IReadOnlyDictionary<string, string>? fileVariables = null,
             IDictionary<string, string>? environmentVariables = null)
@@ -41,7 +41,7 @@ namespace RESTClient.NET.Core.Processing
                     if (fileVariables.TryGetValue(variableName, out var value))
                     {
                         // Recursively resolve variables in the value
-                        return ResolveVariables(value, fileVariables, environmentVariables);
+                        return ResolveVariables(value, fileVariables, environmentVariables) ?? string.Empty;
                     }
 
                     // Return original if variable not found
@@ -58,7 +58,7 @@ namespace RESTClient.NET.Core.Processing
                     
                     if (environmentVariables.TryGetValue(variableName, out var value))
                     {
-                        return value;
+                        return value ?? string.Empty;
                     }
 
                     // Try system environment variables as fallback
@@ -98,8 +98,8 @@ namespace RESTClient.NET.Core.Processing
             var processedRequest = new HttpRequest
             {
                 Name = request.Name,
-                Method = ResolveVariables(request.Method, fileVariables, environmentVariables),
-                Url = ResolveVariables(request.Url, fileVariables, environmentVariables),
+                Method = ResolveVariables(request.Method, fileVariables, environmentVariables) ?? string.Empty,
+                Url = ResolveVariables(request.Url, fileVariables, environmentVariables) ?? string.Empty,
                 Body = ResolveVariables(request.Body, fileVariables, environmentVariables),
                 LineNumber = request.LineNumber
             };
@@ -107,8 +107,8 @@ namespace RESTClient.NET.Core.Processing
             // Process headers
             foreach (var header in request.Headers)
             {
-                var processedName = ResolveVariables(header.Key, fileVariables, environmentVariables);
-                var processedValue = ResolveVariables(header.Value, fileVariables, environmentVariables);
+                var processedName = ResolveVariables(header.Key, fileVariables, environmentVariables) ?? header.Key;
+                var processedValue = ResolveVariables(header.Value, fileVariables, environmentVariables) ?? header.Value;
                 processedRequest.Headers[processedName] = processedValue;
             }
 

--- a/src/RESTClient.NET.Core/RESTClient.NET.Core.csproj
+++ b/src/RESTClient.NET.Core/RESTClient.NET.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>RESTClient.NET.Core</PackageId>
     <PackageVersion>1.0.0-preview.1</PackageVersion>
@@ -23,7 +24,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/RESTClient.NET.Core/RESTClient.NET.Core.csproj
+++ b/src/RESTClient.NET.Core/RESTClient.NET.Core.csproj
@@ -18,6 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>

--- a/src/RESTClient.NET.Core/Validation/ValidationResult.cs
+++ b/src/RESTClient.NET.Core/Validation/ValidationResult.cs
@@ -189,25 +189,6 @@ namespace RESTClient.NET.Core.Validation
         /// <summary>
         /// Invalid expectation format
         /// </summary>
-        InvalidExpectation,
-
-        // Legacy compatibility - these will be removed in a future version
-        /// <summary>
-        /// Invalid or missing request ID
-        /// </summary>
-        [Obsolete("Use InvalidRequestName instead. This value will be removed in a future version.")]
-        InvalidRequestId = InvalidRequestName,
-
-        /// <summary>
-        /// Duplicate request ID
-        /// </summary>
-        [Obsolete("Use DuplicateRequestName instead. This value will be removed in a future version.")]
-        DuplicateRequestId = DuplicateRequestName,
-
-        /// <summary>
-        /// Missing required request ID
-        /// </summary>
-        [Obsolete("Use MissingRequestName instead. This value will be removed in a future version.")]
-        MissingRequestId = MissingRequestName
+        InvalidExpectation
     }
 }

--- a/tests/RESTClient.NET.Core.Tests/Models/HttpFileTests.cs
+++ b/tests/RESTClient.NET.Core.Tests/Models/HttpFileTests.cs
@@ -12,8 +12,8 @@ namespace RESTClient.NET.Core.Tests.Models
             // Arrange
             var requests = new List<HttpRequest>
             {
-                new HttpRequest { RequestId = "test1", Method = "GET", Url = "http://example.com" },
-                new HttpRequest { RequestId = "test2", Method = "POST", Url = "http://api.com" }
+                new HttpRequest { Name = "test1", Method = "GET", Url = "http://example.com" },
+                new HttpRequest { Name = "test2", Method = "POST", Url = "http://api.com" }
             };
 
             var fileVariables = new Dictionary<string, string>
@@ -42,38 +42,38 @@ namespace RESTClient.NET.Core.Tests.Models
         }
 
         [Fact]
-        public void TryGetRequestById_WithExistingId_ShouldReturnTrue()
+        public void TryGetRequestByName_WithExistingId_ShouldReturnTrue()
         {
             // Arrange
             var requests = new List<HttpRequest>
             {
-                new HttpRequest { RequestId = "test1", Method = "GET", Url = "http://example.com" },
-                new HttpRequest { RequestId = "test2", Method = "POST", Url = "http://api.com" }
+                new HttpRequest { Name = "test1", Method = "GET", Url = "http://example.com" },
+                new HttpRequest { Name = "test2", Method = "POST", Url = "http://api.com" }
             };
             var httpFile = new HttpFile(requests);
 
             // Act
-            var result = httpFile.TryGetRequestById("test1", out var request);
+            var result = httpFile.TryGetRequestByName("test1", out var request);
 
             // Assert
             result.Should().BeTrue();
             request.Should().NotBeNull();
-            request!.RequestId.Should().Be("test1");
+            request!.Name.Should().Be("test1");
             request.Method.Should().Be("GET");
         }
 
         [Fact]
-        public void TryGetRequestById_WithNonExistingId_ShouldReturnFalse()
+        public void TryGetRequestByName_WithNonExistingId_ShouldReturnFalse()
         {
             // Arrange
             var requests = new List<HttpRequest>
             {
-                new HttpRequest { RequestId = "test1", Method = "GET", Url = "http://example.com" }
+                new HttpRequest { Name = "test1", Method = "GET", Url = "http://example.com" }
             };
             var httpFile = new HttpFile(requests);
 
             // Act
-            var result = httpFile.TryGetRequestById("nonexistent", out var request);
+            var result = httpFile.TryGetRequestByName("nonexistent", out var request);
 
             // Assert
             result.Should().BeFalse();
@@ -81,71 +81,71 @@ namespace RESTClient.NET.Core.Tests.Models
         }
 
         [Fact]
-        public void TryGetRequestById_WithNullOrEmptyId_ShouldReturnFalse()
+        public void TryGetRequestByName_WithNullOrEmptyId_ShouldReturnFalse()
         {
             // Arrange
             var requests = new List<HttpRequest>
             {
-                new HttpRequest { RequestId = "test1", Method = "GET", Url = "http://example.com" }
+                new HttpRequest { Name = "test1", Method = "GET", Url = "http://example.com" }
             };
             var httpFile = new HttpFile(requests);
 
             // Act & Assert
-            httpFile.TryGetRequestById(null, out var request1).Should().BeFalse();
+            httpFile.TryGetRequestByName(null, out var request1).Should().BeFalse();
             request1.Should().BeNull();
 
-            httpFile.TryGetRequestById("", out var request2).Should().BeFalse();
+            httpFile.TryGetRequestByName("", out var request2).Should().BeFalse();
             request2.Should().BeNull();
 
-            httpFile.TryGetRequestById("   ", out var request3).Should().BeFalse();
+            httpFile.TryGetRequestByName("   ", out var request3).Should().BeFalse();
             request3.Should().BeNull();
         }
 
         [Fact]
-        public void GetRequestById_WithExistingId_ShouldReturnRequest()
+        public void GetRequestByName_WithExistingId_ShouldReturnRequest()
         {
             // Arrange
             var requests = new List<HttpRequest>
             {
-                new HttpRequest { RequestId = "test1", Method = "GET", Url = "http://example.com" },
-                new HttpRequest { RequestId = "test2", Method = "POST", Url = "http://api.com" }
+                new HttpRequest { Name = "test1", Method = "GET", Url = "http://example.com" },
+                new HttpRequest { Name = "test2", Method = "POST", Url = "http://api.com" }
             };
             var httpFile = new HttpFile(requests);
 
             // Act
-            var request = httpFile.GetRequestById("test2");
+            var request = httpFile.GetRequestByName("test2");
 
             // Assert
             request.Should().NotBeNull();
-            request.RequestId.Should().Be("test2");
+            request.Name.Should().Be("test2");
             request.Method.Should().Be("POST");
         }
 
         [Fact]
-        public void GetRequestById_WithNonExistingId_ShouldThrowKeyNotFoundException()
+        public void GetRequestByName_WithNonExistingId_ShouldThrowKeyNotFoundException()
         {
             // Arrange
             var requests = new List<HttpRequest>
             {
-                new HttpRequest { RequestId = "test1", Method = "GET", Url = "http://example.com" }
+                new HttpRequest { Name = "test1", Method = "GET", Url = "http://example.com" }
             };
             var httpFile = new HttpFile(requests);
 
             // Act & Assert
-            Action act = () => httpFile.GetRequestById("nonexistent");
+            Action act = () => httpFile.GetRequestByName("nonexistent");
             act.Should().Throw<KeyNotFoundException>()
                 .WithMessage("Request with name 'nonexistent' not found");
         }
 
         [Fact]
-        public void Constructor_WithDuplicateRequestIds_ShouldStoreAllRequests()
+        public void Constructor_WithDuplicateNames_ShouldStoreAllRequests()
         {
             // Arrange
             var requests = new List<HttpRequest>
             {
-                new HttpRequest { RequestId = "duplicate", Method = "GET", Url = "http://example.com" },
-                new HttpRequest { RequestId = "duplicate", Method = "POST", Url = "http://api.com" },
-                new HttpRequest { RequestId = "unique", Method = "PUT", Url = "http://other.com" }
+                new HttpRequest { Name = "duplicate", Method = "GET", Url = "http://example.com" },
+                new HttpRequest { Name = "duplicate", Method = "POST", Url = "http://api.com" },
+                new HttpRequest { Name = "unique", Method = "PUT", Url = "http://other.com" }
             };
 
             // Act
@@ -155,7 +155,7 @@ namespace RESTClient.NET.Core.Tests.Models
             httpFile.Requests.Should().HaveCount(3);
             
             // The lookup should return the first occurrence
-            var foundRequest = httpFile.GetRequestById("duplicate");
+            var foundRequest = httpFile.GetRequestByName("duplicate");
             foundRequest.Method.Should().Be("GET");
         }
 
@@ -165,7 +165,7 @@ namespace RESTClient.NET.Core.Tests.Models
             // Arrange
             var requests = new List<HttpRequest>
             {
-                new HttpRequest { RequestId = "test1", Method = "GET", Url = "http://example.com" }
+                new HttpRequest { Name = "test1", Method = "GET", Url = "http://example.com" }
             };
 
             // Act
@@ -182,7 +182,7 @@ namespace RESTClient.NET.Core.Tests.Models
             // Arrange
             var requests = new List<HttpRequest>
             {
-                new HttpRequest { RequestId = "test1", Method = "GET", Url = "http://example.com" }
+                new HttpRequest { Name = "test1", Method = "GET", Url = "http://example.com" }
             };
 
             var fileVariables = new Dictionary<string, string>

--- a/tests/RESTClient.NET.Core.Tests/Models/HttpFileTests.cs
+++ b/tests/RESTClient.NET.Core.Tests/Models/HttpFileTests.cs
@@ -37,7 +37,7 @@ namespace RESTClient.NET.Core.Tests.Models
         public void Constructor_WithNullRequests_ShouldThrowArgumentNullException()
         {
             // Act & Assert
-            Action act = () => new HttpFile(null);
+            Action act = () => new HttpFile(null!);
             act.Should().Throw<ArgumentNullException>().WithParameterName("requests");
         }
 
@@ -91,7 +91,7 @@ namespace RESTClient.NET.Core.Tests.Models
             var httpFile = new HttpFile(requests);
 
             // Act & Assert
-            httpFile.TryGetRequestByName(null, out var request1).Should().BeFalse();
+            httpFile.TryGetRequestByName(null!, out var request1).Should().BeFalse();
             request1.Should().BeNull();
 
             httpFile.TryGetRequestByName("", out var request2).Should().BeFalse();

--- a/tests/RESTClient.NET.Core.Tests/Parsing/HttpFileParserTests.cs
+++ b/tests/RESTClient.NET.Core.Tests/Parsing/HttpFileParserTests.cs
@@ -88,14 +88,14 @@ DELETE http://localhost:5000/api/users/1";
             result.Should().NotBeNull();
             result.Requests.Should().HaveCount(3);
 
-            var getRequest = result.GetRequestById("get-users");
+            var getRequest = result.GetRequestByName("get-users");
             getRequest.Method.Should().Be("GET");
 
-            var postRequest = result.GetRequestById("create-user");
+            var postRequest = result.GetRequestByName("create-user");
             postRequest.Method.Should().Be("POST");
             postRequest.Headers["Content-Type"].Should().Be("application/json");
 
-            var deleteRequest = result.GetRequestById("delete-user");
+            var deleteRequest = result.GetRequestByName("delete-user");
             deleteRequest.Method.Should().Be("DELETE");
         }
 
@@ -159,7 +159,7 @@ GET http://localhost:5000/api/users";
         }
 
         [Fact]
-        public async Task ParseAsync_WithDuplicateRequestIds_ShouldThrowDuplicateRequestIdException()
+        public async Task ParseAsync_WithDuplicateRequestNames_ShouldThrowDuplicateRequestNameException()
         {
             // Arrange
             var content = @"### duplicate-id
@@ -177,7 +177,7 @@ POST http://localhost:5000/api/users";
         }
 
         [Fact]
-        public async Task ParseAsync_WithMissingRequestId_ShouldThrowMissingRequestIdException()
+        public async Task ParseAsync_WithMissingRequestName_ShouldThrowMissingRequestNameException()
         {
             // Arrange
             var content = @"###
@@ -195,7 +195,7 @@ GET http://localhost:5000/api/users";
         }
 
         [Fact]
-        public async Task ParseAsync_WithInvalidRequestId_ShouldThrowInvalidRequestIdException()
+        public async Task ParseAsync_WithInvalidRequestName_ShouldThrowInvalidRequestNameException()
         {
             // Arrange
             var content = @"### invalid request id with spaces
@@ -280,7 +280,7 @@ GET http://localhost:5000/api/users
 ### duplicate-id
 POST http://localhost:5000/api/users";
 
-            var options = new HttpParseOptions { ValidateRequestIds = false };
+            var options = new HttpParseOptions { ValidateRequestNames = false };
             var parser = new HttpFileParser();
 
             // Act

--- a/tests/RESTClient.NET.Core.Tests/RESTClient.NET.Core.Tests.csproj
+++ b/tests/RESTClient.NET.Core.Tests/RESTClient.NET.Core.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
- Remove unused System.Text.Json package (security vulnerability)
- Add TreatWarningsAsErrors to both projects
- Fix nullable reference type warnings in HttpFileProcessor, HttpFile, VariableProcessor
- Fix async method warning in HttpFileParser
- Fix nullable parameter warnings in test files
- All 47 tests still passing
- Build now succeeds with 0 warnings (down from 27)