### PR TITLE
docs: add NuGet badges and VS Code REST Client link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 [![CI](https://github.com/Meir017/vscode-restclient-dotnet/actions/workflows/ci.yml/badge.svg)](https://github.com/Meir017/vscode-restclient-dotnet/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/Meir017/vscode-restclient-dotnet/branch/main/graph/badge.svg)](https://codecov.io/gh/Meir017/vscode-restclient-dotnet)
+[![RESTClient.NET.Core](https://img.shields.io/nuget/v/RESTClient.NET.Core.svg?label=RESTClient.NET.Core)](https://www.nuget.org/packages/RESTClient.NET.Core/)
+[![RESTClient.NET.Testing](https://img.shields.io/nuget/v/RESTClient.NET.Testing.svg?label=RESTClient.NET.Testing)](https://www.nuget.org/packages/RESTClient.NET.Testing/)
 
-A comprehensive C# library for parsing HTTP files with full VS Code REST Client compatibility and ASP.NET Core integration testing capabilities.
+A comprehensive C# library for parsing HTTP files with full [VS Code REST Client](https://github.com/Huachao/vscode-restclient) compatibility and ASP.NET Core integration testing capabilities.
 
 ## 🚀 Features
 
@@ -24,7 +26,7 @@ A comprehensive C# library for parsing HTTP files with full VS Code REST Client 
 ## 🛠️ Installation
 
 ```bash
-# Core library (available soon)
+# Core library
 dotnet add package RESTClient.NET.Core
 
 # Testing framework (coming soon)


### PR DESCRIPTION
## Description
Enhances the README.md with NuGet package badges and reference link to the original VS Code REST Client extension.

## Type of Change
- [x] Documentation update

## Changes Made
- **Added NuGet Badges**: Added version badges for both RESTClient.NET.Core and RESTClient.NET.Testing packages with package names in labels
- **VS Code REST Client Link**: Added hyperlink to the original VS Code REST Client GitHub repository (https://github.com/Huachao/vscode-restclient)
- **Installation Update**: Updated installation instructions to reflect that the Core package is now available (removed "available soon" text)

## Benefits
- **Package Visibility**: Users can immediately see current package versions and access NuGet pages
- **Clear Reference**: Direct link to the VS Code extension that defines the .http file format this library supports
- **Improved UX**: Better user experience with clear package availability status

## How Has This Been Tested?
- [x] Markdown rendering verified
- [x] Links tested and working
- [x] Badge URLs validated

## Checklist
- [x] My changes follow the documentation style guidelines
- [x] I have verified all links are working
- [x] Badge URLs are correct and point to valid NuGet packages
- [x] Changes are purely documentation improvements with no code impact